### PR TITLE
Fix load

### DIFF
--- a/src/main/java/net/elytrium/limboauth/socialaddon/Addon.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/Addon.java
@@ -125,9 +125,9 @@ public class Addon {
     this.requestedReverseMap = new HashMap<>();
   }
 
-  @Subscribe(order = PostOrder.FIRST)
-  public void onProxyInitialization(ProxyInitializeEvent event) {
-    this.load();
+  @Subscribe(order = PostOrder.NORMAL)
+  public void onProxyInitialization(ProxyInitializeEvent event) throws SQLException {
+    this.onReload();
     this.metricsFactory.make(this, 14770);
     UpdatesChecker.checkForUpdates(this.logger);
   }


### PR DESCRIPTION
Change this.load() to this.onReload() and ProxyInitializeEvent's priority to normal because the plugin loads before LimboAuth.