### PR TITLE
Velocity b274 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,9 +49,14 @@ dependencies {
 
     implementation("net.dv8tion:JDA:$jdaVersion") {
         exclude module: "opus-java"
+        exclude module: "slf4j-api"
     }
-    implementation("org.telegram:telegrambots:$telegrambotsVersion")
-    implementation("com.vk.api:sdk:$vkVersion")
+    implementation("org.telegram:telegrambots:$telegrambotsVersion") {
+        exclude module: "slf4j-api"
+    }
+    implementation("com.vk.api:sdk:$vkVersion") {
+        exclude module: "slf4j-api"
+    }
 
     implementation("com.maxmind.geoip2:geoip2:$geoipVersion")
     implementation("org.apache.commons:commons-compress:$apacheCompressCommonsVersion")

--- a/build.gradle
+++ b/build.gradle
@@ -49,14 +49,9 @@ dependencies {
 
     implementation("net.dv8tion:JDA:$jdaVersion") {
         exclude module: "opus-java"
-        exclude module: "slf4j-api"
     }
-    implementation("org.telegram:telegrambots:$telegrambotsVersion") {
-        exclude module: "slf4j-api"
-    }
-    implementation("com.vk.api:sdk:$vkVersion") {
-        exclude module: "slf4j-api"
-    }
+    implementation("org.telegram:telegrambots:$telegrambotsVersion")
+    implementation("com.vk.api:sdk:$vkVersion")
 
     implementation("com.maxmind.geoip2:geoip2:$geoipVersion")
     implementation("org.apache.commons:commons-compress:$apacheCompressCommonsVersion")
@@ -71,6 +66,7 @@ shadowJar {
     exclude("META-INF/maven/**")
     exclude("META-INF/INFO_BIN")
     exclude("META-INF/INFO_SRC")
+    exclude("org/slf4j/**")
     exclude("google/protobuf/**")
     exclude("com/google/protobuf/**")
     exclude("org/apache/commons/codec/language/**")

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 setGroup("net.elytrium")
-setVersion("1.0.10")
+setVersion("1.0.11-SNAPSHOT")
 
 compileJava {
     getOptions().setEncoding("UTF-8")


### PR DESCRIPTION
As Velocity b274+ is bundled with SLF4J v2, we should exclude older versions as using them will cause issues with JDA.