### PR TITLE
Add multi-account support for social button handling

### DIFF
--- a/src/main/java/net/elytrium/limboauth/socialaddon/Addon.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/Addon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -28,15 +28,12 @@ import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.PluginContainer;
 import com.velocitypowered.api.plugin.PluginDescription;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
-import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
-import com.velocitypowered.api.proxy.ServerConnection;
-import com.velocitypowered.api.scheduler.ScheduledTask;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.nio.file.Path;
 import java.sql.SQLException;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -44,17 +41,16 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
-import net.elytrium.commons.config.Placeholders;
 import net.elytrium.commons.kyori.serialization.Serializer;
 import net.elytrium.commons.kyori.serialization.Serializers;
 import net.elytrium.commons.utils.updates.UpdatesChecker;
 import net.elytrium.limboauth.LimboAuth;
-import net.elytrium.limboauth.handler.AuthSessionHandler;
-import net.elytrium.limboauth.model.RegisteredPlayer;
 import net.elytrium.limboauth.socialaddon.command.ForceSocialUnlinkCommand;
 import net.elytrium.limboauth.socialaddon.command.ValidateLinkCommand;
+import net.elytrium.limboauth.socialaddon.handler.ButtonHandlers;
+import net.elytrium.limboauth.socialaddon.handler.MessageHandler;
 import net.elytrium.limboauth.socialaddon.listener.LimboAuthListener;
 import net.elytrium.limboauth.socialaddon.listener.ReloadListener;
 import net.elytrium.limboauth.socialaddon.model.SocialPlayer;
@@ -78,24 +74,13 @@ import org.slf4j.Logger;
     name = "LimboAuth Social Addon",
     version = BuildConstants.ADDON_VERSION,
     url = "https://elytrium.net/",
-    authors = {
-        "Elytrium (https://elytrium.net/)",
-    },
-    dependencies = {
-        @Dependency(id = "limboauth")
-    }
+    authors = {"Elytrium (https://elytrium.net/)"},
+    dependencies = {@Dependency(id = "limboauth")}
 )
 public class Addon {
 
-  private static final String INFO_BTN = "info";
-  private static final String BLOCK_BTN = "block";
-  private static final String TOTP_BTN = "2fa";
-  private static final String NOTIFY_BTN = "notify";
-  private static final String KICK_BTN = "kick";
-  private static final String RESTORE_BTN = "restore";
-  private static final String UNLINK_BTN = "unlink";
+  private static final String SELECT_BTN_PREFIX = "sel_";
   private static final String PLUGIN_MINIMUM_VERSION = "1.1.0";
-
   private static Serializer SERIALIZER;
 
   private final ProxyServer server;
@@ -104,17 +89,29 @@ public class Addon {
   private final Path dataDirectory;
   private final LimboAuth plugin;
 
-  private final Map<String, Integer> codeMap;
-  private final Map<String, TempAccount> requestedReverseMap;
+  // Legacy link flow (bot → game)
+  private final Map<String, Integer> codeMap = new ConcurrentHashMap<>();
+  private final Map<String, TempAccount> requestedReverseMap = new ConcurrentHashMap<>();
   private final Map<String, CachedRegisteredUser> cachedAccountRegistrations = new ConcurrentHashMap<>();
+
+  // New link flow (game → bot → game)
+  private final Map<String, Integer> linkInitCodeMap = new ConcurrentHashMap<>();
+  private final Map<String, String> linkInitFieldMap = new ConcurrentHashMap<>();
+  private final Map<String, String> linkInitSocialNameMap = new ConcurrentHashMap<>();
+  private final Map<String, Integer> confirmCodeMap = new ConcurrentHashMap<>();
+
+  // Unlink confirmation
+  private final Map<String, SocialPlayer> pendingUnlinks = new ConcurrentHashMap<>();
+
+  // Multi-account selection
+  private final Map<String, PendingAction> pendingActions = new ConcurrentHashMap<>();
 
   private Dao<SocialPlayer, String> dao;
   private Pattern nicknamePattern;
-
   private SocialManager socialManager;
   private List<List<AbstractSocial.ButtonItem>> keyboard;
   private GeoIp geoIp;
-  private ScheduledTask purgeCacheTask;
+  private net.elytrium.limboauth.socialaddon.social.AbstractSocial.ButtonVisibility defaultVisibility;
 
   static {
     Objects.requireNonNull(org.apache.commons.logging.impl.LogFactoryImpl.class);
@@ -122,19 +119,9 @@ public class Addon {
     Objects.requireNonNull(org.apache.commons.logging.impl.Jdk14Logger.class);
     Objects.requireNonNull(org.apache.commons.logging.impl.Jdk13LumberjackLogger.class);
     Objects.requireNonNull(org.apache.commons.logging.impl.SimpleLog.class);
-
-    // 'api.host' and 'oauth.host' is used by vk-java-sdk
-    if (System.getProperty("api.host") == null) {
-      System.setProperty("api.host", "api.vk.ru");
-    }
-
-    if (System.getProperty("oauth.host") == null) {
-      System.setProperty("oauth.host", "oauth.vk.ru");
-    }
   }
 
   @Inject
-  @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
   public Addon(ProxyServer server, Logger logger, Metrics.Factory metricsFactory, @DataDirectory Path dataDirectory) {
     this.server = server;
     this.logger = logger;
@@ -149,8 +136,6 @@ public class Addon {
     }
 
     this.plugin = (LimboAuth) container.flatMap(PluginContainer::getInstance).orElseThrow();
-    this.codeMap = new ConcurrentHashMap<>();
-    this.requestedReverseMap = new ConcurrentHashMap<>();
   }
 
   @Subscribe(order = PostOrder.NORMAL)
@@ -187,435 +172,87 @@ public class Addon {
     this.socialManager.start();
 
     this.keyboard = List.of(
+        List.of(new AbstractSocial.ButtonItem("info", Settings.IMP.MAIN.STRINGS.INFO_BTN, AbstractSocial.ButtonItem.Color.PRIMARY)),
         List.of(
-            new AbstractSocial.ButtonItem(INFO_BTN, Settings.IMP.MAIN.STRINGS.INFO_BTN, AbstractSocial.ButtonItem.Color.PRIMARY)
+            new AbstractSocial.ButtonItem("block", Settings.IMP.MAIN.STRINGS.BLOCK_TOGGLE_BTN, AbstractSocial.ButtonItem.Color.SECONDARY),
+            new AbstractSocial.ButtonItem("2fa", Settings.IMP.MAIN.STRINGS.TOGGLE_2FA_BTN, AbstractSocial.ButtonItem.Color.SECONDARY)
         ),
+        List.of(new AbstractSocial.ButtonItem("notify", Settings.IMP.MAIN.STRINGS.TOGGLE_NOTIFICATION_BTN, AbstractSocial.ButtonItem.Color.SECONDARY)),
         List.of(
-            new AbstractSocial.ButtonItem(BLOCK_BTN, Settings.IMP.MAIN.STRINGS.BLOCK_TOGGLE_BTN, AbstractSocial.ButtonItem.Color.SECONDARY),
-            new AbstractSocial.ButtonItem(TOTP_BTN, Settings.IMP.MAIN.STRINGS.TOGGLE_2FA_BTN, AbstractSocial.ButtonItem.Color.SECONDARY)
-        ),
-        List.of(
-            new AbstractSocial.ButtonItem(NOTIFY_BTN, Settings.IMP.MAIN.STRINGS.TOGGLE_NOTIFICATION_BTN, AbstractSocial.ButtonItem.Color.SECONDARY)
-        ),
-        List.of(
-            new AbstractSocial.ButtonItem(KICK_BTN, Settings.IMP.MAIN.STRINGS.KICK_BTN, AbstractSocial.ButtonItem.Color.RED),
-            new AbstractSocial.ButtonItem(RESTORE_BTN, Settings.IMP.MAIN.STRINGS.RESTORE_BTN, AbstractSocial.ButtonItem.Color.RED),
-            new AbstractSocial.ButtonItem(UNLINK_BTN, Settings.IMP.MAIN.STRINGS.UNLINK_BTN, AbstractSocial.ButtonItem.Color.RED)
+            new AbstractSocial.ButtonItem("kick", Settings.IMP.MAIN.STRINGS.KICK_BTN, AbstractSocial.ButtonItem.Color.RED),
+            new AbstractSocial.ButtonItem("restore", Settings.IMP.MAIN.STRINGS.RESTORE_BTN, AbstractSocial.ButtonItem.Color.RED),
+            new AbstractSocial.ButtonItem("unlink", Settings.IMP.MAIN.STRINGS.UNLINK_BTN, AbstractSocial.ButtonItem.Color.RED)
         )
     );
-
     this.socialManager.registerKeyboard(this.keyboard);
 
-    this.socialManager.addMessageEvent((dbField, id, message) -> {
-      String lowercaseMessage = message.toLowerCase(Locale.ROOT);
-      if (Settings.IMP.MAIN.START_MESSAGES.contains(lowercaseMessage)) {
-        this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.START_REPLY);
-        return;
-      }
+    // Register unlink confirm buttons for value→id mapping
+    this.socialManager.registerKeyboard(List.of(List.of(
+        new AbstractSocial.ButtonItem("unlink_yes", Settings.IMP.MAIN.STRINGS.UNLINK_CONFIRM_YES, AbstractSocial.ButtonItem.Color.RED),
+        new AbstractSocial.ButtonItem("unlink_no", Settings.IMP.MAIN.STRINGS.UNLINK_CONFIRM_NO, AbstractSocial.ButtonItem.Color.GREEN)
+    )));
 
-      for (String socialRegisterCmd : Settings.IMP.MAIN.SOCIAL_REGISTER_CMDS) {
-        if (lowercaseMessage.startsWith(socialRegisterCmd)) {
-          int desiredLength = socialRegisterCmd.length() + 1;
-
-          if (message.length() <= desiredLength) {
-            this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_SOCIAL_REGISTER_CMD_USAGE);
-            return;
-          }
-
-          String userIndex = dbField + id;
-          CachedRegisteredUser cachedRegisteredUser = this.cachedAccountRegistrations.get(userIndex);
-          if (cachedRegisteredUser == null) {
-            this.cachedAccountRegistrations.put(userIndex, cachedRegisteredUser = new CachedRegisteredUser());
-          }
-
-          if (cachedRegisteredUser.getRegistrationAmount() >= Settings.IMP.MAIN.MAX_REGISTRATION_COUNT_PER_TIME) {
-            this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.REGISTER_LIMIT);
-            return;
-          }
-
-          cachedRegisteredUser.incrementRegistrationAmount();
-
-          if (this.dao.queryForEq(dbField, id).size() != 0) {
-            this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_ALREADY);
-            return;
-          }
-
-          String account = message.substring(desiredLength);
-          if (!this.nicknamePattern.matcher(account).matches()) {
-            this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.REGISTER_INCORRECT_NICKNAME);
-            return;
-          }
-
-          String lowercaseNickname = account.toLowerCase(Locale.ROOT);
-          if (this.plugin.getPlayerDao().idExists(lowercaseNickname)) {
-            this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.REGISTER_TAKEN_NICKNAME);
-            return;
-          }
-
-          if (!Settings.IMP.MAIN.ALLOW_PREMIUM_NAMES_REGISTRATION && this.plugin.isPremium(lowercaseNickname)) {
-            this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.REGISTER_PREMIUM_NICKNAME);
-            return;
-          }
-
-          String newPassword = Long.toHexString(Double.doubleToLongBits(Math.random()));
-
-          RegisteredPlayer player = new RegisteredPlayer(account, "", "").setPassword(newPassword);
-          this.plugin.getPlayerDao().create(player);
-
-          this.linkSocial(lowercaseNickname, dbField, id);
-          this.socialManager.broadcastMessage(dbField, id,
-              Placeholders.replace(Settings.IMP.MAIN.STRINGS.REGISTER_SUCCESS, newPassword));
+    // Register sel_0..sel_9 for account selection
+    for (int i = 0; i < 10; i++) {
+      final int index = i;
+      String btnId = SELECT_BTN_PREFIX + i;
+      this.socialManager.registerButton(new AbstractSocial.ButtonItem(btnId, btnId, AbstractSocial.ButtonItem.Color.PRIMARY));
+      this.socialManager.removeButtonEvent(btnId);
+      this.socialManager.addButtonEvent(btnId, (dbField, id) -> {
+        PendingAction pending = this.pendingActions.remove(dbField + id);
+        if (pending == null) return;
+        List<SocialPlayer> accounts = pending.getAccounts();
+        if (index < accounts.size()) {
+          pending.getAction().accept(accounts.get(index));
         }
-      }
+      });
+    }
 
-      for (String socialLinkCmd : Settings.IMP.MAIN.SOCIAL_LINK_CMDS) {
-        if (lowercaseMessage.startsWith(socialLinkCmd)) {
-          int desiredLength = socialLinkCmd.length() + 1;
+    // Register button handlers
+    new ButtonHandlers(this, this.socialManager, this.dao, this.plugin, this.geoIp).registerAll();
 
-          if (message.length() <= desiredLength) {
-            this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_SOCIAL_CMD_USAGE);
-            return;
-          }
-
-          String[] args = message.substring(desiredLength).split(" ");
-          if (this.dao.queryForEq(dbField, id).size() != 0) {
-            this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_ALREADY);
-            return;
-          }
-
-          String account = args[0].toLowerCase(Locale.ROOT);
-          if (!this.nicknamePattern.matcher(account).matches()) {
-            this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_UNKNOWN_ACCOUNT);
-            return;
-          }
-
-          if (args.length == 1) {
-            if (Settings.IMP.MAIN.DISABLE_LINK_WITHOUT_PASSWORD) {
-              this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_SOCIAL_CMD_USAGE);
-              return;
-            }
-
-            int code = ThreadLocalRandom.current().nextInt(Settings.IMP.MAIN.CODE_LOWER_BOUND, Settings.IMP.MAIN.CODE_UPPER_BOUND);
-            this.codeMap.put(account, code);
-            this.requestedReverseMap.put(account, new TempAccount(dbField, id));
-            this.socialManager.broadcastMessage(dbField, id, Placeholders.replace(Settings.IMP.MAIN.STRINGS.LINK_CODE, String.valueOf(code)));
-          } else {
-            if (Settings.IMP.MAIN.DISABLE_LINK_WITH_PASSWORD) {
-              this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_SOCIAL_CMD_USAGE);
-              return;
-            }
-
-            RegisteredPlayer registeredPlayer = this.plugin.getPlayerDao().queryForId(account);
-            if (AuthSessionHandler.checkPassword(args[1], registeredPlayer, this.plugin.getPlayerDao())) {
-              this.linkSocial(account, dbField, id);
-              this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_SUCCESS);
-            } else {
-              this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_WRONG_PASSWORD);
-              return;
-            }
-          }
-
-          return;
-        }
-      }
-
-      for (String forceKeyboardCmd : Settings.IMP.MAIN.FORCE_KEYBOARD_CMDS) {
-        if (lowercaseMessage.startsWith(forceKeyboardCmd)) {
-          if (this.dao.queryBuilder().where().eq(dbField, id).countOf() == 0) {
-            this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.START_REPLY);
-            return;
-          }
-
-          this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.KEYBOARD_RESTORED, this.keyboard);
-          return;
-        }
-      }
-    });
-
-    this.socialManager.addButtonEvent(INFO_BTN, (dbField, id) -> {
-      List<SocialPlayer> socialPlayerList = this.dao.queryForEq(dbField, id);
-
-      if (socialPlayerList.size() == 0) {
-        return;
-      }
-
-      SocialPlayer player = socialPlayerList.get(0);
-      Optional<Player> proxyPlayer = this.server.getPlayer(player.getLowercaseNickname());
-      String server;
-      String ip;
-      String location;
-
-      if (proxyPlayer.isPresent()) {
-        Player player1 = proxyPlayer.get();
-        Optional<ServerConnection> connection = player1.getCurrentServer();
-
-        if (connection.isPresent()) {
-          server = connection.get().getServerInfo().getName();
-        } else {
-          server = Settings.IMP.MAIN.STRINGS.STATUS_OFFLINE;
-        }
-
-        ip = player1.getRemoteAddress().getAddress().getHostAddress();
-        location = Optional.ofNullable(this.geoIp).map(nonNullGeo -> nonNullGeo.getLocation(ip)).orElse("");
-      } else {
-        server = Settings.IMP.MAIN.STRINGS.STATUS_OFFLINE;
-        ip = Settings.IMP.MAIN.STRINGS.STATUS_OFFLINE;
-        location = "";
-      }
-
-      this.socialManager.broadcastMessage(dbField, id, Placeholders.replace(Settings.IMP.MAIN.STRINGS.INFO_MSG,
-              player.getLowercaseNickname(),
-              server,
-              ip,
-              location,
-              player.isNotifyEnabled() ? Settings.IMP.MAIN.STRINGS.NOTIFY_ENABLED : Settings.IMP.MAIN.STRINGS.NOTIFY_DISABLED,
-              player.isBlocked() ? Settings.IMP.MAIN.STRINGS.BLOCK_ENABLED : Settings.IMP.MAIN.STRINGS.BLOCK_DISABLED,
-              player.isTotpEnabled() ? Settings.IMP.MAIN.STRINGS.TOTP_ENABLED : Settings.IMP.MAIN.STRINGS.TOTP_DISABLED),
-          this.keyboard
-      );
-    });
-
-    this.socialManager.addButtonEvent(BLOCK_BTN, (dbField, id) -> {
-      List<SocialPlayer> socialPlayerList = this.dao.queryForEq(dbField, id);
-
-      if (socialPlayerList.size() == 0) {
-        return;
-      }
-
-      SocialPlayer player = socialPlayerList.get(0);
-
-      if (player.isBlocked()) {
-        player.setBlocked(false);
-        this.socialManager.broadcastMessage(dbField, id,
-            Placeholders.replace(Settings.IMP.MAIN.STRINGS.UNBLOCK_SUCCESS, player.getLowercaseNickname()), this.keyboard
-        );
-      } else {
-        player.setBlocked(true);
-
-        this.plugin.removePlayerFromCache(player.getLowercaseNickname());
-        this.server
-            .getPlayer(player.getLowercaseNickname())
-            .ifPresent(e -> e.disconnect(Addon.getSerializer().deserialize(Settings.IMP.MAIN.STRINGS.KICK_GAME_MESSAGE)));
-
-        this.socialManager.broadcastMessage(dbField, id,
-            Placeholders.replace(Settings.IMP.MAIN.STRINGS.BLOCK_SUCCESS, player.getLowercaseNickname()), this.keyboard
-        );
-      }
-
-      this.dao.update(player);
-    });
-
-    this.socialManager.addButtonEvent(TOTP_BTN, (dbField, id) -> {
-      List<SocialPlayer> socialPlayerList = this.dao.queryForEq(dbField, id);
-
-      if (socialPlayerList.size() == 0) {
-        return;
-      }
-
-      SocialPlayer player = socialPlayerList.get(0);
-
-      if (player.isTotpEnabled()) {
-        player.setTotpEnabled(false);
-        this.socialManager.broadcastMessage(dbField, id,
-            Placeholders.replace(Settings.IMP.MAIN.STRINGS.TOTP_DISABLE_SUCCESS, player.getLowercaseNickname()), this.keyboard
-        );
-      } else {
-        player.setTotpEnabled(true);
-        this.socialManager.broadcastMessage(dbField, id,
-            Placeholders.replace(Settings.IMP.MAIN.STRINGS.TOTP_ENABLE_SUCCESS, player.getLowercaseNickname()), this.keyboard
-        );
-      }
-
-      this.dao.update(player);
-    });
-
-    this.socialManager.addButtonEvent(NOTIFY_BTN, (dbField, id) -> {
-      List<SocialPlayer> socialPlayerList = this.dao.queryForEq(dbField, id);
-
-      if (socialPlayerList.size() == 0) {
-        return;
-      }
-
-      SocialPlayer player = socialPlayerList.get(0);
-
-      if (player.isNotifyEnabled()) {
-        player.setNotifyEnabled(false);
-        this.socialManager.broadcastMessage(dbField, id,
-            Placeholders.replace(Settings.IMP.MAIN.STRINGS.NOTIFY_DISABLE_SUCCESS, player.getLowercaseNickname()), this.keyboard
-        );
-      } else {
-        player.setNotifyEnabled(true);
-        this.socialManager.broadcastMessage(dbField, id,
-            Placeholders.replace(Settings.IMP.MAIN.STRINGS.NOTIFY_ENABLE_SUCCESS, player.getLowercaseNickname()), this.keyboard
-        );
-      }
-
-      this.dao.update(player);
-    });
-
-    this.socialManager.addButtonEvent(KICK_BTN, (dbField, id) -> {
-      List<SocialPlayer> socialPlayerList = this.dao.queryForEq(dbField, id);
-
-      if (socialPlayerList.size() == 0) {
-        return;
-      }
-
-      SocialPlayer player = socialPlayerList.get(0);
-      Optional<Player> proxyPlayer = this.server.getPlayer(player.getLowercaseNickname());
-      this.plugin.removePlayerFromCache(player.getLowercaseNickname());
-
-      if (proxyPlayer.isPresent()) {
-        proxyPlayer.get().disconnect(Addon.getSerializer().deserialize(Settings.IMP.MAIN.STRINGS.KICK_GAME_MESSAGE));
-        this.socialManager.broadcastMessage(dbField, id,
-            Placeholders.replace(Settings.IMP.MAIN.STRINGS.KICK_SUCCESS, player.getLowercaseNickname()), this.keyboard
-        );
-      } else {
-        this.socialManager.broadcastMessage(dbField, id,
-            Settings.IMP.MAIN.STRINGS.KICK_IS_OFFLINE.replace("{NICKNAME}", player.getLowercaseNickname()), this.keyboard
-        );
-      }
-
-      this.dao.update(player);
-    });
-
-    this.socialManager.addButtonEvent(RESTORE_BTN, (dbField, id) -> {
-      List<SocialPlayer> socialPlayerList = this.dao.queryForEq(dbField, id);
-
-      if (socialPlayerList.size() == 0) {
-        return;
-      }
-
-      SocialPlayer player = socialPlayerList.get(0);
-
-      if (Settings.IMP.MAIN.PROHIBIT_PREMIUM_RESTORE
-          && this.plugin.isPremiumInternal(player.getLowercaseNickname()).getState() != LimboAuth.PremiumState.CRACKED) {
-        this.socialManager.broadcastMessage(dbField, id,
-            Placeholders.replace(Settings.IMP.MAIN.STRINGS.RESTORE_MSG_PREMIUM, player.getLowercaseNickname()),
-            this.keyboard
-        );
-        return;
-      }
-
-      Dao<RegisteredPlayer, String> playerDao = this.plugin.getPlayerDao();
-
-      String newPassword = Long.toHexString(Double.doubleToLongBits(Math.random()));
-
-      UpdateBuilder<RegisteredPlayer, String> updateBuilder = playerDao.updateBuilder();
-      updateBuilder.where().eq(RegisteredPlayer.LOWERCASE_NICKNAME_FIELD, player.getLowercaseNickname());
-      updateBuilder.updateColumnValue(RegisteredPlayer.HASH_FIELD, RegisteredPlayer.genHash(newPassword));
-      boolean updated = updateBuilder.update() != 0;
-
-      if (updated) {
-        this.socialManager.broadcastMessage(dbField, id,
-            Placeholders.replace(Settings.IMP.MAIN.STRINGS.RESTORE_MSG, player.getLowercaseNickname(), newPassword),
-            this.keyboard
-        );
-      } else {
-        this.socialManager.broadcastMessage(dbField, id,
-            Placeholders.replace(Settings.IMP.MAIN.STRINGS.RESTORE_MSG_PREMIUM, player.getLowercaseNickname()),
-            this.keyboard
-        );
-      }
-    });
-
-    this.socialManager.addButtonEvent(UNLINK_BTN, (dbField, id) -> {
-      if (Settings.IMP.MAIN.DISABLE_UNLINK) {
-        this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.UNLINK_DISABLED, this.keyboard);
-        return;
-      }
-      List<SocialPlayer> socialPlayerList = this.dao.queryForEq(dbField, id);
-
-      if (socialPlayerList.size() == 0) {
-        return;
-      }
-
-      SocialPlayer player = socialPlayerList.get(0);
-
-      if (player.isBlocked()) {
-        this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.UNLINK_BLOCK_CONFLICT, this.keyboard);
-        return;
-      }
-
-      if (player.isTotpEnabled()) {
-        this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.UNLINK_2FA_CONFLICT, this.keyboard);
-        return;
-      }
-
-      Long playerId = SocialPlayer.DatabaseField.valueOf(dbField).getIdFor(player);
-      SocialPlayer.DatabaseField.valueOf(dbField).setIdFor(player, null);
-      boolean allUnlinked = Arrays.stream(SocialPlayer.DatabaseField.values())
-          .noneMatch(v -> v.getIdFor(player) != null);
-      SocialPlayer.DatabaseField.valueOf(dbField).setIdFor(player, playerId);
-
-      if (Settings.IMP.MAIN.UNLINK_BTN_ALL || allUnlinked) {
-        this.socialManager.unregisterHook(player);
-        this.dao.delete(player);
-
-        Settings.IMP.MAIN.AFTER_UNLINKAGE_COMMANDS.forEach(command ->
-            this.server.getCommandManager().executeAsync(p -> Tristate.TRUE, command.replace("{NICKNAME}", player.getLowercaseNickname())));
-      } else {
-        UpdateBuilder<SocialPlayer, String> updateBuilder = this.dao.updateBuilder();
-        updateBuilder.where().eq(SocialPlayer.LOWERCASE_NICKNAME_FIELD, player.getLowercaseNickname());
-        updateBuilder.updateColumnValue(dbField, null);
-        updateBuilder.update();
-
-        this.socialManager.unregisterHook(dbField, player);
-      }
-
-      this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.UNLINK_SUCCESS);
-      this.server.getPlayer(player.getLowercaseNickname()).ifPresent(p ->
-          p.sendMessage(SERIALIZER.deserialize(Settings.IMP.MAIN.STRINGS.UNLINK_SUCCESS_GAME)));
-    });
+    // Register message handler
+    this.socialManager.addMessageEvent(new MessageHandler(this, this.socialManager, this.dao));
   }
 
   public void onReload() throws SQLException {
-    this.load();
     this.server.getEventManager().unregisterListeners(this);
 
     ConnectionSource source = this.plugin.getConnectionSource();
     TableUtils.createTableIfNotExists(source, SocialPlayer.class);
     this.dao = DaoManager.createDao(source, SocialPlayer.class);
-
     this.plugin.migrateDb(this.dao);
-
     this.nicknamePattern = Pattern.compile(net.elytrium.limboauth.Settings.IMP.MAIN.ALLOWED_NICKNAME_REGEX);
 
-    this.server.getEventManager().register(this, new LimboAuthListener(this, this.plugin, this.dao, this.socialManager,
-        this.keyboard, this.geoIp
-    ));
+    // load() must be called AFTER dao is initialized
+    this.load();
+
+    this.server.getEventManager().register(this, new LimboAuthListener(this, this.plugin, this.dao, this.socialManager, this.keyboard, this.geoIp));
     this.server.getEventManager().register(this, new ReloadListener(this));
-
-    if (this.purgeCacheTask != null) {
-      this.purgeCacheTask.cancel();
-    }
-
-    this.purgeCacheTask = this.server.getScheduler()
-        .buildTask(this, () -> this.checkCache(this.cachedAccountRegistrations, Settings.IMP.MAIN.PURGE_REGISTRATION_CACHE_MILLIS))
-        .delay(net.elytrium.limboauth.Settings.IMP.MAIN.PURGE_CACHE_MILLIS, TimeUnit.MILLISECONDS)
-        .repeat(net.elytrium.limboauth.Settings.IMP.MAIN.PURGE_CACHE_MILLIS, TimeUnit.MILLISECONDS)
-        .schedule();
 
     CommandManager commandManager = this.server.getCommandManager();
     commandManager.unregister(Settings.IMP.MAIN.LINKAGE_MAIN_CMD);
     commandManager.unregister(Settings.IMP.MAIN.FORCE_UNLINK_MAIN_CMD);
-
-    commandManager.register(
-        Settings.IMP.MAIN.LINKAGE_MAIN_CMD,
-        new ValidateLinkCommand(this),
-        Settings.IMP.MAIN.LINKAGE_ALIAS_CMD.toArray(new String[0])
-    );
-    commandManager.register(
-        Settings.IMP.MAIN.FORCE_UNLINK_MAIN_CMD,
-        new ForceSocialUnlinkCommand(this),
-        Settings.IMP.MAIN.FORCE_UNLINK_ALIAS_CMD.toArray(new String[0])
-    );
+    commandManager.register(Settings.IMP.MAIN.LINKAGE_MAIN_CMD, new ValidateLinkCommand(this), Settings.IMP.MAIN.LINKAGE_ALIAS_CMD.toArray(new String[0]));
+    commandManager.register(Settings.IMP.MAIN.FORCE_UNLINK_MAIN_CMD, new ForceSocialUnlinkCommand(this), Settings.IMP.MAIN.FORCE_UNLINK_ALIAS_CMD.toArray(new String[0]));
   }
 
-  private void checkCache(Map<?, ? extends CachedUser> userMap, long time) {
-    userMap.entrySet().stream()
-        .filter(userEntry -> userEntry.getValue().getCheckTime() + time <= System.currentTimeMillis())
-        .map(Map.Entry::getKey)
-        .forEach(userMap::remove);
+  // ── Public API ────────────────────────────────────────────────────────────
+
+  public void linkSocial(String lowercaseNickname, String dbField, Long id) throws SQLException {
+    SocialPlayer socialPlayer = this.dao.queryForId(lowercaseNickname);
+    if (socialPlayer == null) {
+      Settings.IMP.MAIN.AFTER_LINKAGE_COMMANDS.forEach(cmd ->
+          this.server.getCommandManager().executeAsync(p -> Tristate.TRUE, cmd.replace("{NICKNAME}", lowercaseNickname)));
+      this.dao.create(new SocialPlayer(lowercaseNickname));
+    } else if (!Settings.IMP.MAIN.ALLOW_ACCOUNT_RELINK && SocialPlayer.DatabaseField.valueOf(dbField).getIdFor(socialPlayer) != null) {
+      this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_ALREADY);
+      return;
+    }
+    UpdateBuilder<SocialPlayer, String> ub = this.dao.updateBuilder();
+    ub.where().eq(SocialPlayer.LOWERCASE_NICKNAME_FIELD, lowercaseNickname);
+    ub.updateColumnValue(dbField, id);
+    ub.update();
   }
 
   public void unregisterPlayer(String nickname) {
@@ -630,51 +267,73 @@ public class Addon {
     }
   }
 
-  public void linkSocial(String lowercaseNickname, String dbField, Long id) throws SQLException {
-    SocialPlayer socialPlayer = this.dao.queryForId(lowercaseNickname);
-    if (socialPlayer == null) {
-      Settings.IMP.MAIN.AFTER_LINKAGE_COMMANDS.forEach(command ->
-          this.server.getCommandManager().executeAsync(p -> Tristate.TRUE, command.replace("{NICKNAME}", lowercaseNickname)));
+  public boolean isAlreadyLinked(String lowercaseNickname, String dbField) throws SQLException {
+    SocialPlayer player = this.dao.queryForId(lowercaseNickname);
+    return player != null && SocialPlayer.DatabaseField.valueOf(dbField).getIdFor(player) != null;
+  }
 
-      this.dao.create(new SocialPlayer(lowercaseNickname));
-    } else if (!Settings.IMP.MAIN.ALLOW_ACCOUNT_RELINK && SocialPlayer.DatabaseField.valueOf(dbField).getIdFor(socialPlayer) != null) {
-      this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_ALREADY);
+  public int generateLinkInitCode(String lowercaseNickname, String dbField, String socialName) {
+    int code = ThreadLocalRandom.current().nextInt(Settings.IMP.MAIN.CODE_LOWER_BOUND, Settings.IMP.MAIN.CODE_UPPER_BOUND);
+    this.linkInitCodeMap.put(lowercaseNickname, code);
+    this.linkInitFieldMap.put(lowercaseNickname, dbField);
+    this.linkInitSocialNameMap.put(lowercaseNickname, socialName);
+    return code;
+  }
+
+  /** Removes step-1 maps for nickname, returns the social name */
+  public String clearLinkInitMaps(String nickname) {
+    this.linkInitCodeMap.remove(nickname);
+    this.linkInitFieldMap.remove(nickname);
+    return this.linkInitSocialNameMap.remove(nickname);
+  }
+
+  public Integer getCode(String nickname) { return this.codeMap.get(nickname); }
+  public void removeCode(String nickname) { this.codeMap.remove(nickname); this.requestedReverseMap.remove(nickname); }
+  public Integer getConfirmCode(String nickname) { return this.confirmCodeMap.get(nickname); }
+  public void removeConfirmCode(String nickname) { this.confirmCodeMap.remove(nickname); this.requestedReverseMap.remove(nickname); }
+  public TempAccount getTempAccount(String nickname) { return this.requestedReverseMap.get(nickname); }
+
+  public void withAccountSelection(String dbField, Long id, List<SocialPlayer> accounts, Consumer<SocialPlayer> action) {
+    if (accounts.size() == 1) {
+      action.accept(accounts.get(0));
       return;
     }
-
-    UpdateBuilder<SocialPlayer, String> updateBuilder = this.dao.updateBuilder();
-    updateBuilder.where().eq(SocialPlayer.LOWERCASE_NICKNAME_FIELD, lowercaseNickname);
-    updateBuilder.updateColumnValue(dbField, id);
-    updateBuilder.update();
+    List<List<AbstractSocial.ButtonItem>> selectionButtons = new ArrayList<>();
+    int limit = Math.min(accounts.size(), 10);
+    for (int i = 0; i < limit; i++) {
+      String nickname = accounts.get(i).getLowercaseNickname();
+      String btnId = SELECT_BTN_PREFIX + i;
+      selectionButtons.add(List.of(new AbstractSocial.ButtonItem(btnId, nickname, AbstractSocial.ButtonItem.Color.PRIMARY)));
+      this.socialManager.registerButton(new AbstractSocial.ButtonItem(btnId, nickname, AbstractSocial.ButtonItem.Color.PRIMARY));
+    }
+    this.pendingActions.put(dbField + id, new PendingAction(accounts, action));
+    this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.SELECT_ACCOUNT_MSG, selectionButtons, AbstractSocial.ButtonVisibility.PREFER_INLINE);
   }
 
-  public Integer getCode(String nickname) {
-    return this.codeMap.get(nickname);
+  public CachedRegisteredUser getCachedRegistration(String userIndex) {
+    return this.cachedAccountRegistrations.computeIfAbsent(userIndex, k -> new CachedRegisteredUser());
   }
 
-  public TempAccount getTempAccount(String nickname) {
-    return this.requestedReverseMap.get(nickname);
-  }
+  // ── Getters ───────────────────────────────────────────────────────────────
 
-  public void removeCode(String nickname) {
-    this.requestedReverseMap.remove(nickname);
-    this.codeMap.remove(nickname);
-  }
+  public SocialManager getSocialManager() { return this.socialManager; }
+  public ProxyServer getServer() { return this.server; }
+  public LimboAuth getPlugin() { return this.plugin; }
+  public List<List<AbstractSocial.ButtonItem>> getKeyboard() { return this.keyboard; }
+  public Pattern getNicknamePattern() { return this.nicknamePattern; }
+  public Map<String, Integer> getCodeMap() { return this.codeMap; }
+  public Map<String, TempAccount> getRequestedReverseMap() { return this.requestedReverseMap; }
+  public Map<String, Integer> getLinkInitCodeMap() { return this.linkInitCodeMap; }
+  public Map<String, String> getLinkInitFieldMap() { return this.linkInitFieldMap; }
+  public Map<String, Integer> getConfirmCodeMap() { return this.confirmCodeMap; }
+  public Map<String, SocialPlayer> getPendingUnlinks() { return this.pendingUnlinks; }
 
-  public SocialManager getSocialManager() {
-    return this.socialManager;
-  }
+  public static Serializer getSerializer() { return SERIALIZER; }
+  private static void setSerializer(Serializer serializer) { SERIALIZER = serializer; }
 
-  public ProxyServer getServer() {
-    return this.server;
-  }
-
-  public List<List<AbstractSocial.ButtonItem>> getKeyboard() {
-    return this.keyboard;
-  }
+  // ── Inner classes ─────────────────────────────────────────────────────────
 
   public static class TempAccount {
-
     private final String dbField;
     private final long id;
 
@@ -683,43 +342,29 @@ public class Addon {
       this.id = id;
     }
 
-    public String getDbField() {
-      return this.dbField;
-    }
-
-    public long getId() {
-      return this.id;
-    }
-
+    public String getDbField() { return this.dbField; }
+    public long getId() { return this.id; }
   }
 
-  private static class CachedUser {
-
+  public static class CachedRegisteredUser {
     private final long checkTime = System.currentTimeMillis();
-
-    public long getCheckTime() {
-      return this.checkTime;
-    }
-  }
-
-  private static class CachedRegisteredUser extends CachedUser {
-
     private int registrationAmount;
 
-    public int getRegistrationAmount() {
-      return this.registrationAmount;
-    }
-
-    public void incrementRegistrationAmount() {
-      this.registrationAmount++;
-    }
+    public long getCheckTime() { return this.checkTime; }
+    public int getRegistrationAmount() { return this.registrationAmount; }
+    public void incrementRegistrationAmount() { this.registrationAmount++; }
   }
 
-  private static void setSerializer(Serializer serializer) {
-    SERIALIZER = serializer;
-  }
+  public static final class PendingAction {
+    private final List<SocialPlayer> accounts;
+    private final Consumer<SocialPlayer> action;
 
-  public static Serializer getSerializer() {
-    return SERIALIZER;
+    public PendingAction(List<SocialPlayer> accounts, Consumer<SocialPlayer> action) {
+      this.accounts = accounts;
+      this.action = action;
+    }
+
+    public List<SocialPlayer> getAccounts() { return this.accounts; }
+    public Consumer<SocialPlayer> getAction() { return this.action; }
   }
 }

--- a/src/main/java/net/elytrium/limboauth/socialaddon/Settings.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/Settings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -31,12 +31,12 @@ public class Settings extends YamlConfig {
   public String VERSION = BuildConstants.ADDON_VERSION;
 
   @Comment({
-      "Available serializers:",
-      "LEGACY_AMPERSAND - \"&c&lExample &c&9Text\".",
-      "LEGACY_SECTION - \"§c§lExample §c§9Text\".",
-      "MINIMESSAGE - \"<bold><red>Example</red> <blue>Text</blue></bold>\". (https://webui.adventure.kyori.net/)",
-      "GSON - \"[{\"text\":\"Example\",\"bold\":true,\"color\":\"red\"},{\"text\":\" \",\"bold\":true},{\"text\":\"Text\",\"bold\":true,\"color\":\"blue\"}]\". (https://minecraft.tools/en/json_text.php/)",
-      "GSON_COLOR_DOWNSAMPLING - Same as GSON, but uses downsampling."
+          "Available serializers:",
+          "LEGACY_AMPERSAND - \"&c&lExample &c&9Text\".",
+          "LEGACY_SECTION - \"§c§lExample §c§9Text\".",
+          "MINIMESSAGE - \"<bold><red>Example</red> <blue>Text</blue></bold>\". (https://webui.adventure.kyori.net/)",
+          "GSON - \"[{\"text\":\"Example\",\"bold\":true,\"color\":\"red\"},{\"text\":\" \",\"bold\":true},{\"text\":\"Text\",\"bold\":true,\"color\":\"blue\"}]\". (https://minecraft.tools/en/json_text.php/)",
+          "GSON_COLOR_DOWNSAMPLING - Same as GSON, but uses downsampling."
   })
   public Serializers SERIALIZER = Serializers.LEGACY_AMPERSAND;
   public String PREFIX = "LimboAuth &6>>&f";
@@ -53,8 +53,8 @@ public class Settings extends YamlConfig {
     public int CODE_LOWER_BOUND = 1000000;
     public int CODE_UPPER_BOUND = 10000000;
 
-    public String LINKAGE_MAIN_CMD = "addsocial";
-    public List<String> LINKAGE_ALIAS_CMD = List.of("addvk", "addtg", "addds");
+    public String LINKAGE_MAIN_CMD = "link";
+    public List<String> LINKAGE_ALIAS_CMD = List.of();
 
     public String FORCE_UNLINK_MAIN_CMD = "forcesocialunlink";
     public List<String> FORCE_UNLINK_ALIAS_CMD = List.of("forceunlink");
@@ -83,9 +83,12 @@ public class Settings extends YamlConfig {
     @Comment("Allow linking social to the player, who already has linked this type of social")
     public boolean ALLOW_ACCOUNT_RELINK = true;
 
+    @Comment("Max Minecraft accounts that can be linked to one social account (per social type)")
+    public int MAX_ACCOUNTS_PER_SOCIAL = 3;
+
     public List<String> AFTER_LINKAGE_COMMANDS = List.of("alert {NICKNAME} has linked a social account");
     public List<String> AFTER_UNLINKAGE_COMMANDS = List.of();
-    public List<String> START_MESSAGES = List.of("/start", "Начать");
+    public List<String> START_MESSAGES = List.of("/start", "Start");
     public String START_REPLY = "Send '!account link <nickname>' to link your account";
 
     @Comment("Addon will print all exceptions if this parameter is set to true.")
@@ -95,14 +98,14 @@ public class Settings extends YamlConfig {
     public boolean PROHIBIT_PREMIUM_RESTORE = true;
 
     @Comment({
-        "NO | YES - with the option disabled",
-        "YES | NO - with the option enabled",
+            "NO | YES - with the option disabled",
+            "YES | NO - with the option enabled",
     })
     public boolean REVERSE_YES_NO_BUTTONS = false;
 
     @Comment({
-        "false - players with social 2FA enabled should enter the password",
-        "true - players with social 2FA enabled can login without the password"
+            "false - players with social 2FA enabled should enter the password",
+            "true - players with social 2FA enabled can login without the password"
     })
     public boolean AUTH_2FA_WITHOUT_PASSWORD = false;
 
@@ -111,6 +114,9 @@ public class Settings extends YamlConfig {
 
     @Comment("How many accounts can register the player per time (per purge-registration-cache-millis)")
     public int MAX_REGISTRATION_COUNT_PER_TIME = 3;
+
+    public String TELEGRAM_BOT_NAME = "@your_telegram_bot";
+    public String DISCORD_BOT_NAME = "YourDiscordBot#0000";
 
     @Create
     public MAIN.VK VK;
@@ -128,15 +134,15 @@ public class Settings extends YamlConfig {
       public String TOKEN = "1234567890";
 
       @Comment({
-          "Available: ",
-          "addrole <role id>",
-          "remrole <role id>",
-          "",
-          "Example: ",
-          "on-player-added: ",
-          " - addrole 12345678",
-          "on-player-removed: ",
-          " - remrole 12345678"
+              "Available: ",
+              "addrole <role id>",
+              "remrole <role id>",
+              "",
+              "Example: ",
+              "on-player-added: ",
+              " - addrole 12345678",
+              "on-player-removed: ",
+              " - remrole 12345678"
       })
       public List<String> ON_PLAYER_ADDED = List.of();
       public List<String> ON_PLAYER_REMOVED = List.of();
@@ -149,16 +155,16 @@ public class Settings extends YamlConfig {
       public String ACTIVITY_NAME = "LimboAuth Social Addon";
 
       @Comment({
-          "Which role ids a player must have on the Discord server to use the bot",
-          "",
-          "Example: ",
-          "required-roles: ",
-          " - 1234567890"
+              "Which role ids a player must have on the Discord server to use the bot",
+              "",
+              "Example: ",
+              "required-roles: ",
+              " - 1234567890"
       })
       public List<Object> REQUIRED_ROLES = List.of();
       @Comment({
-          "It's better to keep this option enabled if you have set required-roles config option",
-          "Requires SERVER MEMBERS INTENT to be enabled in the bot settings on the Discord Developer Portal"
+              "It's better to keep this option enabled if you have set required-roles config option",
+              "Requires SERVER MEMBERS INTENT to be enabled in the bot settings on the Discord Developer Portal"
       })
       public boolean GUILD_MEMBER_CACHE_ENABLED = false;
       public String NO_ROLES_MESSAGE = "You don't have permission to use commands";
@@ -170,32 +176,33 @@ public class Settings extends YamlConfig {
     public static class TELEGRAM {
       public boolean ENABLED = false;
       public String TOKEN = "1234567890";
+      public String BOT_NAME = "@your_telegram_bot";
     }
 
     @Create
     public MAIN.GEOIP GEOIP;
 
     @Comment({
-        "GeoIP is an offline database providing approximate IP address locations",
-        "In the SocialAddon's case, the IP location is displayed in notifications and alerts"
+            "GeoIP is an offline database providing approximate IP address locations",
+            "In the SocialAddon's case, the IP location is displayed in notifications and alerts"
     })
     public static class GEOIP {
       public boolean ENABLED = false;
       @Comment({
-          "Available placeholders: {CITY}, {COUNTRY}, {LEAST_SPECIFIC_SUBDIVISION}, {MOST_SPECIFIC_SUBDIVISION}"
+              "Available placeholders: {CITY}, {COUNTRY}, {LEAST_SPECIFIC_SUBDIVISION}, {MOST_SPECIFIC_SUBDIVISION}"
       })
       @Placeholders({"{CITY}", "{COUNTRY}", "{LEAST_SPECIFIC_SUBDIVISION}", "{MOST_SPECIFIC_SUBDIVISION}"})
       public String FORMAT = "{CITY}, {COUNTRY}";
       @Comment("ISO 639-1")
       public String LOCALE = "en";
       @Comment({
-          "MaxMind license key",
-          "Regenerate if triggers an error"
+              "MaxMind license key",
+              "Regenerate if triggers an error"
       })
       public String LICENSE_KEY = "P5g0fVdAQIq8yQau";
       @Comment({
-          "The interval at which the database will be updated, in milliseconds",
-          "Default value: 14 days"
+              "The interval at which the database will be updated, in milliseconds",
+              "Default value: 14 days"
       })
       public long UPDATE_INTERVAL = 1209600000L;
       public String DEFAULT_VALUE = "Unknown";
@@ -217,9 +224,23 @@ public class Settings extends YamlConfig {
       public String LINK_CMD_USAGE = "{PRFX} Send '!account link {NICKNAME}' to our Social Bot{NL} VK: vk.com/123{NL} DS: Bot#0000{NL} TG: @bot";
       @Placeholders({"{NICKNAME}"})
       public String LINK_WRONG_CODE = "{PRFX} Wrong code, run '!account link {NICKNAME}' again";
-      public String LINK_SUCCESS_GAME = "{PRFX} Social was successfully linked";
+      public String LINK_CODE_CORRECT = "{PRFX} Code is correct! Account successfully linked.";
+      public String LINK_CODE_INCORRECT = "{PRFX} Wrong code. Please try again.";
+      public String LINK_COMMAND_USAGE = "{PRFX} Usage: /link <tg|ds>";
+      public String LINK_AVAILABLE_OPTIONS = "{NL}&6▸ &fAvailable options: &ads&f, &atg{NL}&6▸ &fUse &c/link TG/DS{NL}";
+      public String LINK_ALREADY_EXISTS = "{PRFX} You already have a linked account. Please unlink it first.";
+      @Placeholders({"{BOT}", "{SOCIAL}"})
+      public String LINK_INSTRUCTION = "{NL} &fLinking to &c{SOCIAL}: {NL}{NL} &71. &fHover over {CODE_LINK}&f to see the code. {NL} &72. &fOpen bot &c{BOT} {NL} &73. &fSend the code to the bot.";
+      @Placeholders({"{BOT}", "{SOCIAL}"})
+      public String LINK_NEW_INSTRUCTION = "{NL} &fLinking to &c{SOCIAL}: {NL}{NL} &71. &fHover over {CODE_LINK}&f to see the code. {NL} &72. &fOpen bot &c{BOT} {NL} &73. &fSend the code to the bot.";
+      @Placeholders({"{CODE}"})
+      public String LINK_CODE_HOVER = "&c{CODE} &f- click to copy";
+      public String LINK_CODE_LINK_TEXT = "&c&nhere&r";      @Placeholders({"{SOCIAL}", "{SOCIAL_NAME}", "{CODE}"})
+      public String LINK_CONFIRM_GAME = "{PRFX} User &c{SOCIAL_NAME} &rwants to link this account.{NL}If that's you — enter &c/link {CODE}&r to confirm.{NL}Otherwise — just ignore this message.";
+      public String LINK_BOT_ALMOST_DONE = "Almost done! Return to the game and read the message in chat.";      public String LINK_SUCCESS_GAME = "{PRFX} Social was successfully linked";
       public String LINK_SUCCESS = "✅ Social was successfully linked{NL}Use '!keyboard' to show keyboard";
       public String LINK_ALREADY = "Account is already linked";
+      public String LINK_MAX_ACCOUNTS = "{PRFX} The maximum number of linked accounts for this social network has been reached.";
       public String LINK_SOCIAL_REGISTER_CMD_USAGE = "You didn't specify a nickname. Enter '!account register <nickname>'";
       public String LINK_SOCIAL_CMD_USAGE = "You didn't specify a nickname. Enter '!account link <nickname>'";
       public String LINK_UNKNOWN_ACCOUNT = "There is no account with this nickname";
@@ -296,6 +317,11 @@ public class Settings extends YamlConfig {
       public String UNLINK_SUCCESS_GAME = "{PRFX} Unlink successful";
       public String UNLINK_BLOCK_CONFLICT = "You cannot unlink the social while your account is blocked. Unblock it first";
       public String UNLINK_2FA_CONFLICT = "You cannot unlink the social while 2FA is enabled. Disable it first";
+      @Placeholders("{NICKNAME}")
+      public String UNLINK_CONFIRM_MSG = "Are you sure you want to unlink account {NICKNAME}?";
+      public String UNLINK_CONFIRM_YES = "Yes, unlink";
+      public String UNLINK_CONFIRM_NO = "No, cancel";
+      public String UNLINK_CANCELLED = "Unlinking cancelled";
 
       public String KEYBOARD_RESTORED = "Keyboard was restored";
 
@@ -303,6 +329,8 @@ public class Settings extends YamlConfig {
       public String LINK_ANNOUNCEMENT = "{PRFX} Hey! We recommend you to link a social network using the /addsocial command to secure your account";
 
       public String SOCIAL_EXCEPTION_CAUGHT = "An exception occurred while processing your request";
+
+      public String SELECT_ACCOUNT_MSG = "Select account:";
     }
   }
 }

--- a/src/main/java/net/elytrium/limboauth/socialaddon/SocialManager.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/SocialManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -134,6 +134,14 @@ public class SocialManager {
 
   public void registerButton(AbstractSocial.ButtonItem item) {
     this.buttonIdMap.put(item.getValue(), item.getId());
+  }
+
+  public String getUserDisplayName(String dbField, Long id) {
+    return this.socialList.stream()
+        .filter(e -> e.getDbField().equals(dbField))
+        .findFirst()
+        .map(e -> e.getUserDisplayName(id))
+        .orElse(String.valueOf(id));
   }
 
   public void broadcastMessage(SocialPlayer player, String message, List<List<AbstractSocial.ButtonItem>> item) {

--- a/src/main/java/net/elytrium/limboauth/socialaddon/command/ForceSocialUnlinkCommand.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/command/ForceSocialUnlinkCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/main/java/net/elytrium/limboauth/socialaddon/command/ValidateLinkCommand.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/command/ValidateLinkCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -23,9 +23,12 @@ import com.velocitypowered.api.proxy.Player;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Locale;
-import net.elytrium.commons.config.Placeholders;
 import net.elytrium.limboauth.socialaddon.Addon;
 import net.elytrium.limboauth.socialaddon.Settings;
+import net.elytrium.limboauth.socialaddon.model.SocialPlayer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
 
 public class ValidateLinkCommand implements SimpleCommand {
 
@@ -38,46 +41,97 @@ public class ValidateLinkCommand implements SimpleCommand {
   @Override
   public void execute(Invocation invocation) {
     CommandSource source = invocation.source();
+    if (!(source instanceof Player)) {
+      return;
+    }
+
+    Player player = (Player) source;
     String[] args = invocation.arguments();
+    String username = player.getUsername().toLowerCase(Locale.ROOT);
 
-    if (source instanceof Player) {
-      Player player = (Player) source;
+    if (args.length == 0) {
+      player.sendMessage(Addon.getSerializer().deserialize(
+          Settings.IMP.MAIN.STRINGS.LINK_AVAILABLE_OPTIONS));
+      return;
+    }
 
-      if (args.length == 0) {
-        this.sendUsage(player);
+    String arg = args[0].toLowerCase(Locale.ROOT);
+
+    if (arg.equals("tg") || arg.equals("ds")) {
+      String dbField = arg.equals("tg") ? SocialPlayer.TELEGRAM_DB_FIELD : SocialPlayer.DISCORD_DB_FIELD;
+      String socialName = arg.equals("tg") ? "Telegram" : "Discord";
+      String botName = arg.equals("tg") ? Settings.IMP.MAIN.TELEGRAM_BOT_NAME : Settings.IMP.MAIN.DISCORD_BOT_NAME;
+
+      try {
+        if (this.addon.isAlreadyLinked(username, dbField)) {
+          player.sendMessage(Addon.getSerializer().deserialize(Settings.IMP.MAIN.STRINGS.LINK_ALREADY));
+          return;
+        }
+      } catch (SQLException ex) {
+        throw new IllegalStateException(ex);
+      }
+
+      int codeA = this.addon.generateLinkInitCode(username, dbField, socialName);
+      String codeStr = String.valueOf(codeA);
+
+      String instructionRaw = Settings.IMP.MAIN.STRINGS.LINK_INSTRUCTION
+          .replace("{BOT}", botName)
+          .replace("{SOCIAL}", socialName);
+
+      String hoverText = Settings.IMP.MAIN.STRINGS.LINK_CODE_HOVER.replace("{CODE}", codeStr);
+
+      Component codeLinkComponent = Addon.getSerializer()
+          .deserialize(Settings.IMP.MAIN.STRINGS.LINK_CODE_LINK_TEXT)
+          .hoverEvent(HoverEvent.showText(Addon.getSerializer().deserialize(hoverText)))
+          .clickEvent(ClickEvent.copyToClipboard(codeStr));
+
+      String[] parts = instructionRaw.split("\\{CODE_LINK\\}", -1);
+      Component message = Addon.getSerializer().deserialize(parts[0]);
+      for (int i = 1; i < parts.length; i++) {
+        message = message.append(codeLinkComponent).append(Addon.getSerializer().deserialize(parts[i]));
+      }
+
+      player.sendMessage(message);
+      return;
+    }
+
+    try {
+      int enteredCode = Integer.parseInt(arg);
+      String username2 = player.getUsername().toLowerCase(Locale.ROOT);
+      Integer validCode = this.addon.getConfirmCode(username2);
+
+      if (validCode != null && validCode == enteredCode) {
+        Addon.TempAccount tempAccount = this.addon.getTempAccount(username2);
+        this.addon.linkSocial(username2, tempAccount.getDbField(), tempAccount.getId());
+        this.addon.getSocialManager().registerHook(tempAccount.getDbField(), tempAccount.getId());
+        this.addon.getSocialManager().broadcastMessage(
+            tempAccount.getDbField(), tempAccount.getId(),
+            Settings.IMP.MAIN.STRINGS.LINK_SUCCESS, this.addon.getKeyboard());
+        player.sendMessage(Addon.getSerializer().deserialize(Settings.IMP.MAIN.STRINGS.LINK_SUCCESS_GAME));
+        this.addon.removeConfirmCode(username2);
+      } else if (validCode != null) {
+        player.sendMessage(Addon.getSerializer().deserialize(
+            Settings.IMP.MAIN.STRINGS.LINK_WRONG_CODE.replace("{NICKNAME}", player.getUsername())));
       } else {
-        try {
-          String username = player.getUsername().toLowerCase(Locale.ROOT);
-          Integer validCode = this.addon.getCode(username);
-          if (validCode != null) {
-            if (validCode == Integer.parseInt(args[0])) {
-              Addon.TempAccount tempAccount = this.addon.getTempAccount(username);
-              this.addon.linkSocial(username, tempAccount.getDbField(), tempAccount.getId());
-              this.addon.getSocialManager().registerHook(tempAccount.getDbField(), tempAccount.getId());
-              this.addon.getSocialManager()
-                  .broadcastMessage(tempAccount.getDbField(), tempAccount.getId(), Settings.IMP.MAIN.STRINGS.LINK_SUCCESS, this.addon.getKeyboard());
-              player.sendMessage(Addon.getSerializer().deserialize(Settings.IMP.MAIN.STRINGS.LINK_SUCCESS_GAME));
-            } else {
-              source.sendMessage(Addon.getSerializer()
-                  .deserialize(Placeholders.replace(Settings.IMP.MAIN.STRINGS.LINK_WRONG_CODE, player.getUsername())));
-            }
-
-            this.addon.removeCode(username);
-          } else {
-            this.sendUsage(player);
-          }
-        } catch (NumberFormatException ignored) {
-          this.sendUsage(player);
-        } catch (SQLException ex) {
-          throw new IllegalStateException(ex);
+        Integer oldCode = this.addon.getCode(username2);
+        if (oldCode != null && oldCode == enteredCode) {
+          Addon.TempAccount tempAccount = this.addon.getTempAccount(username2);
+          this.addon.linkSocial(username2, tempAccount.getDbField(), tempAccount.getId());
+          this.addon.getSocialManager().registerHook(tempAccount.getDbField(), tempAccount.getId());
+          this.addon.getSocialManager().broadcastMessage(
+              tempAccount.getDbField(), tempAccount.getId(),
+              Settings.IMP.MAIN.STRINGS.LINK_SUCCESS, this.addon.getKeyboard());
+          player.sendMessage(Addon.getSerializer().deserialize(Settings.IMP.MAIN.STRINGS.LINK_SUCCESS_GAME));
+          this.addon.removeCode(username2);
+        } else {
+          player.sendMessage(Addon.getSerializer().deserialize(Settings.IMP.MAIN.STRINGS.LINK_AVAILABLE_OPTIONS));
         }
       }
+    } catch (NumberFormatException ignored) {
+      player.sendMessage(Addon.getSerializer().deserialize(Settings.IMP.MAIN.STRINGS.LINK_AVAILABLE_OPTIONS));
+    } catch (SQLException ex) {
+      throw new IllegalStateException(ex);
     }
-  }
-
-  private void sendUsage(Player player) {
-    player.sendMessage(Addon.getSerializer()
-        .deserialize(Placeholders.replace(Settings.IMP.MAIN.STRINGS.LINK_CMD_USAGE, player.getUsername())));
   }
 
   @Override

--- a/src/main/java/net/elytrium/limboauth/socialaddon/handler/ButtonHandlers.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/handler/ButtonHandlers.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (C) 2022 - 2026 Elytrium
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package net.elytrium.limboauth.socialaddon.handler;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import net.elytrium.commons.config.Placeholders;
+import net.elytrium.limboauth.LimboAuth;
+import net.elytrium.limboauth.model.RegisteredPlayer;
+import net.elytrium.limboauth.socialaddon.Addon;
+import net.elytrium.limboauth.socialaddon.Settings;
+import net.elytrium.limboauth.socialaddon.SocialManager;
+import net.elytrium.limboauth.socialaddon.model.SocialPlayer;
+import net.elytrium.limboauth.socialaddon.social.AbstractSocial;
+import net.elytrium.limboauth.socialaddon.utils.GeoIp;
+import net.elytrium.limboauth.thirdparty.com.j256.ormlite.dao.Dao;
+import net.elytrium.limboauth.thirdparty.com.j256.ormlite.stmt.UpdateBuilder;
+import com.velocitypowered.api.permission.Tristate;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ServerConnection;
+
+public class ButtonHandlers {
+
+  private final Addon addon;
+  private final SocialManager socialManager;
+  private final Dao<SocialPlayer, String> dao;
+  private final LimboAuth plugin;
+  private final GeoIp geoIp;
+
+  public ButtonHandlers(Addon addon, SocialManager socialManager, Dao<SocialPlayer, String> dao,
+                        LimboAuth plugin, GeoIp geoIp) {
+    this.addon = addon;
+    this.socialManager = socialManager;
+    this.dao = dao;
+    this.plugin = plugin;
+    this.geoIp = geoIp;
+  }
+
+  public void registerAll() {
+    this.registerInfoBtn();
+    this.registerBlockBtn();
+    this.registerTotpBtn();
+    this.registerNotifyBtn();
+    this.registerKickBtn();
+    this.registerRestoreBtn();
+    this.registerUnlinkBtn();
+    this.registerUnlinkConfirmBtns();
+  }
+
+  private void registerInfoBtn() {
+    this.socialManager.addButtonEvent("info", (dbField, id) -> {
+      List<SocialPlayer> list = this.dao.queryForEq(dbField, id);
+      if (list.isEmpty()) return;
+      this.addon.withAccountSelection(dbField, id, list, player -> {
+        Optional<Player> proxyPlayer = this.addon.getServer().getPlayer(player.getLowercaseNickname());
+        String server, ip, location;
+        if (proxyPlayer.isPresent()) {
+          Player p = proxyPlayer.get();
+          Optional<ServerConnection> conn = p.getCurrentServer();
+          server = conn.map(c -> c.getServerInfo().getName()).orElse(Settings.IMP.MAIN.STRINGS.STATUS_OFFLINE);
+          ip = p.getRemoteAddress().getAddress().getHostAddress();
+          location = Optional.ofNullable(this.geoIp).map(g -> g.getLocation(ip)).orElse("");
+        } else {
+          server = Settings.IMP.MAIN.STRINGS.STATUS_OFFLINE;
+          ip = Settings.IMP.MAIN.STRINGS.STATUS_OFFLINE;
+          location = "";
+        }
+        this.socialManager.broadcastMessage(dbField, id, Placeholders.replace(Settings.IMP.MAIN.STRINGS.INFO_MSG,
+            player.getLowercaseNickname(), server, ip, location,
+            player.isNotifyEnabled() ? Settings.IMP.MAIN.STRINGS.NOTIFY_ENABLED : Settings.IMP.MAIN.STRINGS.NOTIFY_DISABLED,
+            player.isBlocked() ? Settings.IMP.MAIN.STRINGS.BLOCK_ENABLED : Settings.IMP.MAIN.STRINGS.BLOCK_DISABLED,
+            player.isTotpEnabled() ? Settings.IMP.MAIN.STRINGS.TOTP_ENABLED : Settings.IMP.MAIN.STRINGS.TOTP_DISABLED),
+            this.addon.getKeyboard());
+      });
+    });
+  }
+
+  private void registerBlockBtn() {
+    this.socialManager.addButtonEvent("block", (dbField, id) -> {
+      List<SocialPlayer> list = this.dao.queryForEq(dbField, id);
+      if (list.isEmpty()) return;
+      this.addon.withAccountSelection(dbField, id, list, player -> {
+        try {
+          if (player.isBlocked()) {
+            player.setBlocked(false);
+            this.socialManager.broadcastMessage(dbField, id,
+                Placeholders.replace(Settings.IMP.MAIN.STRINGS.UNBLOCK_SUCCESS, player.getLowercaseNickname()), this.addon.getKeyboard());
+          } else {
+            player.setBlocked(true);
+            this.plugin.removePlayerFromCache(player.getLowercaseNickname());
+            this.addon.getServer().getPlayer(player.getLowercaseNickname())
+                .ifPresent(p -> p.disconnect(Addon.getSerializer().deserialize(Settings.IMP.MAIN.STRINGS.KICK_GAME_MESSAGE)));
+            this.socialManager.broadcastMessage(dbField, id,
+                Placeholders.replace(Settings.IMP.MAIN.STRINGS.BLOCK_SUCCESS, player.getLowercaseNickname()), this.addon.getKeyboard());
+          }
+          this.dao.update(player);
+        } catch (SQLException e) { throw new IllegalStateException(e); }
+      });
+    });
+  }
+
+  private void registerTotpBtn() {
+    this.socialManager.addButtonEvent("2fa", (dbField, id) -> {
+      List<SocialPlayer> list = this.dao.queryForEq(dbField, id);
+      if (list.isEmpty()) return;
+      this.addon.withAccountSelection(dbField, id, list, player -> {
+        try {
+          if (player.isTotpEnabled()) {
+            player.setTotpEnabled(false);
+            this.socialManager.broadcastMessage(dbField, id,
+                Placeholders.replace(Settings.IMP.MAIN.STRINGS.TOTP_DISABLE_SUCCESS, player.getLowercaseNickname()), this.addon.getKeyboard());
+          } else {
+            player.setTotpEnabled(true);
+            this.socialManager.broadcastMessage(dbField, id,
+                Placeholders.replace(Settings.IMP.MAIN.STRINGS.TOTP_ENABLE_SUCCESS, player.getLowercaseNickname()), this.addon.getKeyboard());
+          }
+          this.dao.update(player);
+        } catch (SQLException e) { throw new IllegalStateException(e); }
+      });
+    });
+  }
+
+  private void registerNotifyBtn() {
+    this.socialManager.addButtonEvent("notify", (dbField, id) -> {
+      List<SocialPlayer> list = this.dao.queryForEq(dbField, id);
+      if (list.isEmpty()) return;
+      this.addon.withAccountSelection(dbField, id, list, player -> {
+        try {
+          if (player.isNotifyEnabled()) {
+            player.setNotifyEnabled(false);
+            this.socialManager.broadcastMessage(dbField, id,
+                Placeholders.replace(Settings.IMP.MAIN.STRINGS.NOTIFY_DISABLE_SUCCESS, player.getLowercaseNickname()), this.addon.getKeyboard());
+          } else {
+            player.setNotifyEnabled(true);
+            this.socialManager.broadcastMessage(dbField, id,
+                Placeholders.replace(Settings.IMP.MAIN.STRINGS.NOTIFY_ENABLE_SUCCESS, player.getLowercaseNickname()), this.addon.getKeyboard());
+          }
+          this.dao.update(player);
+        } catch (SQLException e) { throw new IllegalStateException(e); }
+      });
+    });
+  }
+
+  private void registerKickBtn() {
+    this.socialManager.addButtonEvent("kick", (dbField, id) -> {
+      List<SocialPlayer> list = this.dao.queryForEq(dbField, id);
+      if (list.isEmpty()) return;
+      this.addon.withAccountSelection(dbField, id, list, player -> {
+        try {
+          Optional<Player> proxyPlayer = this.addon.getServer().getPlayer(player.getLowercaseNickname());
+          this.plugin.removePlayerFromCache(player.getLowercaseNickname());
+          if (proxyPlayer.isPresent()) {
+            proxyPlayer.get().disconnect(Addon.getSerializer().deserialize(Settings.IMP.MAIN.STRINGS.KICK_GAME_MESSAGE));
+            this.socialManager.broadcastMessage(dbField, id,
+                Placeholders.replace(Settings.IMP.MAIN.STRINGS.KICK_SUCCESS, player.getLowercaseNickname()), this.addon.getKeyboard());
+          } else {
+            this.socialManager.broadcastMessage(dbField, id,
+                Settings.IMP.MAIN.STRINGS.KICK_IS_OFFLINE.replace("{NICKNAME}", player.getLowercaseNickname()), this.addon.getKeyboard());
+          }
+          this.dao.update(player);
+        } catch (SQLException e) { throw new IllegalStateException(e); }
+      });
+    });
+  }
+
+  private void registerRestoreBtn() {
+    this.socialManager.addButtonEvent("restore", (dbField, id) -> {
+      List<SocialPlayer> list = this.dao.queryForEq(dbField, id);
+      if (list.isEmpty()) return;
+      this.addon.withAccountSelection(dbField, id, list, player -> {
+        try {
+          if (Settings.IMP.MAIN.PROHIBIT_PREMIUM_RESTORE
+              && this.plugin.isPremiumInternal(player.getLowercaseNickname()).getState() != LimboAuth.PremiumState.CRACKED) {
+            this.socialManager.broadcastMessage(dbField, id,
+                Placeholders.replace(Settings.IMP.MAIN.STRINGS.RESTORE_MSG_PREMIUM, player.getLowercaseNickname()), this.addon.getKeyboard());
+            return;
+          }
+          Dao<RegisteredPlayer, String> playerDao = this.plugin.getPlayerDao();
+          String newPassword = Long.toHexString(Double.doubleToLongBits(Math.random()));
+          UpdateBuilder<RegisteredPlayer, String> ub = playerDao.updateBuilder();
+          ub.where().eq(RegisteredPlayer.LOWERCASE_NICKNAME_FIELD, player.getLowercaseNickname());
+          ub.updateColumnValue(RegisteredPlayer.HASH_FIELD, RegisteredPlayer.genHash(newPassword));
+          if (ub.update() != 0) {
+            this.socialManager.broadcastMessage(dbField, id,
+                Placeholders.replace(Settings.IMP.MAIN.STRINGS.RESTORE_MSG, player.getLowercaseNickname(), newPassword), this.addon.getKeyboard());
+          } else {
+            this.socialManager.broadcastMessage(dbField, id,
+                Placeholders.replace(Settings.IMP.MAIN.STRINGS.RESTORE_MSG_PREMIUM, player.getLowercaseNickname()), this.addon.getKeyboard());
+          }
+        } catch (SQLException e) { throw new IllegalStateException(e); }
+      });
+    });
+  }
+
+  private void registerUnlinkBtn() {
+    this.socialManager.addButtonEvent("unlink", (dbField, id) -> {
+      if (Settings.IMP.MAIN.DISABLE_UNLINK) {
+        this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.UNLINK_DISABLED, this.addon.getKeyboard());
+        return;
+      }
+      List<SocialPlayer> list = this.dao.queryForEq(dbField, id);
+      if (list.isEmpty()) return;
+      this.addon.withAccountSelection(dbField, id, list, player -> {
+        if (player.isBlocked()) {
+          this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.UNLINK_BLOCK_CONFLICT, this.addon.getKeyboard());
+          return;
+        }
+        if (player.isTotpEnabled()) {
+          this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.UNLINK_2FA_CONFLICT, this.addon.getKeyboard());
+          return;
+        }
+        this.addon.getPendingUnlinks().put(dbField + id, player);
+        List<List<AbstractSocial.ButtonItem>> confirmBtns = List.of(List.of(
+            new AbstractSocial.ButtonItem("unlink_yes", Settings.IMP.MAIN.STRINGS.UNLINK_CONFIRM_YES, AbstractSocial.ButtonItem.Color.RED),
+            new AbstractSocial.ButtonItem("unlink_no", Settings.IMP.MAIN.STRINGS.UNLINK_CONFIRM_NO, AbstractSocial.ButtonItem.Color.GREEN)
+        ));
+        this.socialManager.broadcastMessage(dbField, id,
+            Settings.IMP.MAIN.STRINGS.UNLINK_CONFIRM_MSG.replace("{NICKNAME}", player.getLowercaseNickname()),
+            confirmBtns, AbstractSocial.ButtonVisibility.PREFER_INLINE);
+      });
+    });
+  }
+
+  private void registerUnlinkConfirmBtns() {
+    this.socialManager.removeButtonEvent("unlink_yes");
+    this.socialManager.removeButtonEvent("unlink_no");
+
+    this.socialManager.addButtonEvent("unlink_yes", (dbField, id) -> {
+      SocialPlayer player = this.addon.getPendingUnlinks().remove(dbField + id);
+      if (player == null) return;
+      try {
+        if (player.isBlocked()) {
+          this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.UNLINK_BLOCK_CONFLICT, this.addon.getKeyboard());
+          return;
+        }
+        if (player.isTotpEnabled()) {
+          this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.UNLINK_2FA_CONFLICT, this.addon.getKeyboard());
+          return;
+        }
+        SocialPlayer.DatabaseField.valueOf(dbField).setIdFor(player, null);
+        boolean allUnlinked = Arrays.stream(SocialPlayer.DatabaseField.values()).noneMatch(v -> v.getIdFor(player) != null);
+        if (Settings.IMP.MAIN.UNLINK_BTN_ALL || allUnlinked) {
+          this.dao.delete(player);
+          this.socialManager.unregisterHook(player);
+          Settings.IMP.MAIN.AFTER_UNLINKAGE_COMMANDS.forEach(cmd ->
+              this.addon.getServer().getCommandManager().executeAsync(p -> Tristate.TRUE, cmd.replace("{NICKNAME}", player.getLowercaseNickname())));
+        } else {
+          UpdateBuilder<SocialPlayer, String> ub = this.dao.updateBuilder();
+          ub.where().eq(SocialPlayer.LOWERCASE_NICKNAME_FIELD, player.getLowercaseNickname());
+          ub.updateColumnValue(dbField, null);
+          ub.update();
+          this.socialManager.unregisterHook(dbField, player);
+        }
+        this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.UNLINK_SUCCESS, this.addon.getKeyboard());
+        this.addon.getServer().getPlayer(player.getLowercaseNickname()).ifPresent(p ->
+            p.sendMessage(Addon.getSerializer().deserialize(Settings.IMP.MAIN.STRINGS.UNLINK_SUCCESS_GAME)));
+      } catch (SQLException e) { throw new IllegalStateException(e); }
+    });
+
+    this.socialManager.addButtonEvent("unlink_no", (dbField, id) -> {
+      this.addon.getPendingUnlinks().remove(dbField + id);
+      this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.UNLINK_CANCELLED, this.addon.getKeyboard());
+    });
+  }
+}

--- a/src/main/java/net/elytrium/limboauth/socialaddon/handler/MessageHandler.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/handler/MessageHandler.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2022 - 2026 Elytrium
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package net.elytrium.limboauth.socialaddon.handler;
+
+import java.sql.SQLException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import net.elytrium.commons.config.Placeholders;
+import net.elytrium.limboauth.handler.AuthSessionHandler;
+import net.elytrium.limboauth.model.RegisteredPlayer;
+import net.elytrium.limboauth.socialaddon.Addon;
+import net.elytrium.limboauth.socialaddon.Settings;
+import net.elytrium.limboauth.socialaddon.SocialManager;
+import net.elytrium.limboauth.socialaddon.model.SocialPlayer;
+import net.elytrium.limboauth.socialaddon.social.SocialMessageListenerAdapter;
+import net.elytrium.limboauth.thirdparty.com.j256.ormlite.dao.Dao;
+
+public class MessageHandler implements SocialMessageListenerAdapter {
+
+  private final Addon addon;
+  private final SocialManager socialManager;
+  private final Dao<SocialPlayer, String> dao;
+
+  public MessageHandler(Addon addon, SocialManager socialManager, Dao<SocialPlayer, String> dao) {
+    this.addon = addon;
+    this.socialManager = socialManager;
+    this.dao = dao;
+  }
+
+  @Override
+  public void accept(String dbField, Long id, String message) throws SQLException {
+    String lowercaseMessage = message.toLowerCase(Locale.ROOT);
+
+    if (Settings.IMP.MAIN.START_MESSAGES.contains(lowercaseMessage)) {
+      this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.START_REPLY);
+      return;
+    }
+
+    // social-register-cmds
+    for (String cmd : Settings.IMP.MAIN.SOCIAL_REGISTER_CMDS) {
+      if (lowercaseMessage.startsWith(cmd)) {
+        this.handleRegister(dbField, id, message, cmd);
+        return;
+      }
+    }
+
+    // step-1 code: player sent code A to bot
+    try {
+      int receivedCode = Integer.parseInt(lowercaseMessage.trim());
+      if (this.handleCodeA(dbField, id, receivedCode)) {
+        return;
+      }
+    } catch (NumberFormatException ignored) {
+      // not a code
+    }
+
+    // social-link-cmds
+    for (String cmd : Settings.IMP.MAIN.SOCIAL_LINK_CMDS) {
+      if (lowercaseMessage.startsWith(cmd)) {
+        this.handleLink(dbField, id, message, cmd);
+        return;
+      }
+    }
+
+    // force-keyboard-cmds
+    for (String cmd : Settings.IMP.MAIN.FORCE_KEYBOARD_CMDS) {
+      if (lowercaseMessage.startsWith(cmd)) {
+        if (this.dao.queryBuilder().where().eq(dbField, id).countOf() == 0) {
+          this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.START_REPLY);
+        } else {
+          this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.KEYBOARD_RESTORED, this.addon.getKeyboard());
+        }
+        return;
+      }
+    }
+  }
+
+  private void handleRegister(String dbField, Long id, String message, String cmd) throws SQLException {
+    int desiredLength = cmd.length() + 1;
+    if (message.length() <= desiredLength) {
+      this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_SOCIAL_REGISTER_CMD_USAGE);
+      return;
+    }
+
+    String userIndex = dbField + id;
+    Addon.CachedRegisteredUser cached = this.addon.getCachedRegistration(userIndex);
+    if (cached.getRegistrationAmount() >= Settings.IMP.MAIN.MAX_REGISTRATION_COUNT_PER_TIME) {
+      this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.REGISTER_LIMIT);
+      return;
+    }
+    cached.incrementRegistrationAmount();
+
+    String account = message.substring(desiredLength);
+    if (!this.addon.getNicknamePattern().matcher(account).matches()) {
+      this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.REGISTER_INCORRECT_NICKNAME);
+      return;
+    }
+
+    String lowercaseNickname = account.toLowerCase(Locale.ROOT);
+    if (this.addon.getPlugin().getPlayerDao().idExists(lowercaseNickname)) {
+      this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.REGISTER_TAKEN_NICKNAME);
+      return;
+    }
+
+    if (!Settings.IMP.MAIN.ALLOW_PREMIUM_NAMES_REGISTRATION && this.addon.getPlugin().isPremium(lowercaseNickname)) {
+      this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.REGISTER_PREMIUM_NICKNAME);
+      return;
+    }
+
+    String newPassword = Long.toHexString(Double.doubleToLongBits(Math.random()));
+    RegisteredPlayer player = new RegisteredPlayer(account, "", "").setPassword(newPassword);
+    this.addon.getPlugin().getPlayerDao().create(player);
+    this.addon.linkSocial(lowercaseNickname, dbField, id);
+    this.socialManager.broadcastMessage(dbField, id, Placeholders.replace(Settings.IMP.MAIN.STRINGS.REGISTER_SUCCESS, newPassword));
+  }
+
+  private boolean handleCodeA(String dbField, Long id, int receivedCode) throws SQLException {
+    for (Map.Entry<String, Integer> entry : this.addon.getLinkInitCodeMap().entrySet()) {
+      String nickname = entry.getKey();
+      if (entry.getValue() == receivedCode && dbField.equals(this.addon.getLinkInitFieldMap().get(nickname))) {
+
+        if (this.dao.queryForEq(dbField, id).size() >= Settings.IMP.MAIN.MAX_ACCOUNTS_PER_SOCIAL) {
+          this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_MAX_ACCOUNTS);
+          this.addon.clearLinkInitMaps(nickname);
+          return true;
+        }
+
+        int codeB = ThreadLocalRandom.current().nextInt(Settings.IMP.MAIN.CODE_LOWER_BOUND, Settings.IMP.MAIN.CODE_UPPER_BOUND);
+        String socialName = this.addon.clearLinkInitMaps(nickname);
+        if (socialName == null) socialName = dbField;
+
+        this.addon.getConfirmCodeMap().put(nickname, codeB);
+        this.addon.getRequestedReverseMap().put(nickname, new Addon.TempAccount(dbField, id));
+
+        this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_BOT_ALMOST_DONE);
+
+        String socialDisplayName = this.socialManager.getUserDisplayName(dbField, id);
+        final String finalSocialName = socialName;
+        final int finalCodeB = codeB;
+        this.addon.getServer().getPlayer(nickname).ifPresent(p -> p.sendMessage(
+            Addon.getSerializer().deserialize(
+                Settings.IMP.MAIN.STRINGS.LINK_CONFIRM_GAME
+                    .replace("{SOCIAL}", finalSocialName)
+                    .replace("{SOCIAL_NAME}", socialDisplayName)
+                    .replace("{CODE}", String.valueOf(finalCodeB)))));
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void handleLink(String dbField, Long id, String message, String cmd) throws SQLException {
+    int desiredLength = cmd.length() + 1;
+    if (message.length() <= desiredLength) {
+      this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_SOCIAL_CMD_USAGE);
+      return;
+    }
+
+    String[] args = message.substring(desiredLength).split(" ");
+    String account = args[0].toLowerCase(Locale.ROOT);
+
+    if (!this.addon.getNicknamePattern().matcher(account).matches()) {
+      this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_UNKNOWN_ACCOUNT);
+      return;
+    }
+
+    if (args.length == 1) {
+      if (Settings.IMP.MAIN.DISABLE_LINK_WITHOUT_PASSWORD) {
+        this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_SOCIAL_CMD_USAGE);
+        return;
+      }
+      int code = ThreadLocalRandom.current().nextInt(Settings.IMP.MAIN.CODE_LOWER_BOUND, Settings.IMP.MAIN.CODE_UPPER_BOUND);
+      this.addon.getCodeMap().put(account, code);
+      this.addon.getRequestedReverseMap().put(account, new Addon.TempAccount(dbField, id));
+      this.socialManager.broadcastMessage(dbField, id, Placeholders.replace(Settings.IMP.MAIN.STRINGS.LINK_CODE, String.valueOf(code)));
+    } else {
+      if (Settings.IMP.MAIN.DISABLE_LINK_WITH_PASSWORD) {
+        this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_SOCIAL_CMD_USAGE);
+        return;
+      }
+      RegisteredPlayer registeredPlayer = this.addon.getPlugin().getPlayerDao().queryForId(account);
+      if (AuthSessionHandler.checkPassword(args[1], registeredPlayer, this.addon.getPlugin().getPlayerDao())) {
+        this.addon.linkSocial(account, dbField, id);
+        this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_SUCCESS);
+      } else {
+        this.socialManager.broadcastMessage(dbField, id, Settings.IMP.MAIN.STRINGS.LINK_WRONG_PASSWORD);
+      }
+    }
+  }
+}

--- a/src/main/java/net/elytrium/limboauth/socialaddon/handler/PreLoginLimboSessionHandler.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/handler/PreLoginLimboSessionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/main/java/net/elytrium/limboauth/socialaddon/listener/LimboAuthListener.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/listener/LimboAuthListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -96,7 +96,7 @@ public class LimboAuthListener {
     this.socialManager.removeButtonEvent(ASK_YES_BTN);
 
     this.socialManager.addButtonEvent(ASK_NO_BTN, (dbField, id) -> {
-      SocialPlayer player = this.queryPlayer(dbField, id);
+      SocialPlayer player = this.queryPlayerWithSession(dbField, id);
 
       if (player != null && this.sessions.containsKey(player.getLowercaseNickname())) {
         this.sessions.get(player.getLowercaseNickname()).getEvent().completeAndCancel(this.askedKick);
@@ -105,7 +105,7 @@ public class LimboAuthListener {
     });
 
     this.socialManager.addButtonEvent(ASK_YES_BTN, (dbField, id) -> {
-      SocialPlayer player = this.queryPlayer(dbField, id);
+      SocialPlayer player = this.queryPlayerWithSession(dbField, id);
 
       if (player != null && this.sessions.containsKey(player.getLowercaseNickname())) {
         AuthSession authSession = this.sessions.get(player.getLowercaseNickname());
@@ -232,14 +232,19 @@ public class LimboAuthListener {
     }
   }
 
-  private SocialPlayer queryPlayer(String dbField, Long id) {
+  private SocialPlayer queryPlayerWithSession(String dbField, Long id) {
     try {
       List<SocialPlayer> l = this.socialPlayerDao.queryForEq(dbField, id);
-
-      if (l.size() == 0) {
+      if (l.isEmpty()) {
         return null;
       }
-
+      
+      for (SocialPlayer player : l) {
+        if (this.sessions.containsKey(player.getLowercaseNickname())) {
+          return player;
+        }
+      }
+      
       return l.get(0);
     } catch (SQLException e) {
       throw new IllegalStateException(e);

--- a/src/main/java/net/elytrium/limboauth/socialaddon/listener/ReloadListener.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/listener/ReloadListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/main/java/net/elytrium/limboauth/socialaddon/model/SocialPlayer.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/model/SocialPlayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/main/java/net/elytrium/limboauth/socialaddon/social/AbstractSocial.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/social/AbstractSocial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -64,6 +64,8 @@ public abstract class AbstractSocial {
   public abstract void sendMessage(SocialPlayer player, String content, List<List<ButtonItem>> buttons, ButtonVisibility visibility);
 
   public abstract boolean canSend(SocialPlayer player);
+
+  public abstract String getUserDisplayName(Long id);
 
   public static class ButtonItem {
 

--- a/src/main/java/net/elytrium/limboauth/socialaddon/social/DiscordSocial.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/social/DiscordSocial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -17,7 +17,6 @@
 
 package net.elytrium.limboauth.socialaddon.social;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -172,13 +171,24 @@ public class DiscordSocial extends AbstractSocial {
     return player.getDiscordID() != null;
   }
 
+  @Override
+  public String getUserDisplayName(Long id) {
+    try {
+      User user = this.jda.retrieveUserById(id).complete();
+      if (user != null) {
+        return "@" + user.getName();
+      }
+    } catch (Exception ignored) {
+    }
+    return String.valueOf(id);
+  }
+
   private static class Listener extends ListenerAdapter {
 
     private final List<Role> requiredRoles;
     private final SocialMessageListener onMessageReceived;
     private final SocialButtonListener onButtonClicked;
 
-    @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
     Listener(JDA jda, SocialMessageListener onMessageReceived, SocialButtonListener onButtonClicked) {
       List<Role> list = new ArrayList<>();
       for (Object requiredRole : Settings.IMP.MAIN.DISCORD.REQUIRED_ROLES) {

--- a/src/main/java/net/elytrium/limboauth/socialaddon/social/SocialButtonListener.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/social/SocialButtonListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/main/java/net/elytrium/limboauth/socialaddon/social/SocialButtonListenerAdapter.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/social/SocialButtonListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/main/java/net/elytrium/limboauth/socialaddon/social/SocialInitializationException.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/social/SocialInitializationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/main/java/net/elytrium/limboauth/socialaddon/social/SocialMessageListener.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/social/SocialMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/main/java/net/elytrium/limboauth/socialaddon/social/SocialMessageListenerAdapter.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/social/SocialMessageListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/main/java/net/elytrium/limboauth/socialaddon/social/TelegramSocial.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/social/TelegramSocial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -17,7 +17,6 @@
 
 package net.elytrium.limboauth.socialaddon.social;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.stream.Collectors;
 import net.elytrium.limboauth.socialaddon.Settings;
@@ -42,10 +41,8 @@ import org.telegram.telegrambots.updatesreceivers.DefaultBotSession;
 public class TelegramSocial extends AbstractSocial {
 
   private final TelegramBotsApi api;
-  private TGBot bot;
-  private BotSession botSession;
+  private TGBot bot;  private BotSession botSession;
 
-  @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
   public TelegramSocial(SocialMessageListener onMessageReceived, SocialButtonListener onButtonClicked) throws SocialInitializationException {
     super(onMessageReceived, onButtonClicked);
 
@@ -95,6 +92,11 @@ public class TelegramSocial extends AbstractSocial {
 
   @Override
   public void sendMessage(Long id, String content, List<List<ButtonItem>> buttons, ButtonVisibility visibility) {
+    if (buttons.isEmpty()) {
+      this.bot.sendMessage(id, content, null);
+      return;
+    }
+
     ReplyKeyboard keyboard;
     switch (visibility) {
       case PREFER_INLINE: {
@@ -130,6 +132,28 @@ public class TelegramSocial extends AbstractSocial {
     return player.getTelegramID() != null;
   }
 
+  @Override
+  public String getUserDisplayName(Long id) {
+    try {
+      org.telegram.telegrambots.meta.api.methods.groupadministration.GetChat getChat =
+          new org.telegram.telegrambots.meta.api.methods.groupadministration.GetChat();
+      getChat.setChatId(String.valueOf(id));
+      org.telegram.telegrambots.meta.api.objects.Chat chat = this.bot.execute(getChat);
+      String username = chat.getUserName();
+      if (username != null && !username.isEmpty()) {
+        return "@" + username;
+      }
+      String name = chat.getFirstName();
+      if (name != null) {
+        String last = chat.getLastName();
+        return last != null ? name + " " + last : name;
+      }
+      return String.valueOf(id);
+    } catch (TelegramApiException e) {
+      return String.valueOf(id);
+    }
+  }
+
   private static final class TGBot extends TelegramLongPollingBot {
 
     private final String token;
@@ -152,8 +176,7 @@ public class TelegramSocial extends AbstractSocial {
       return this.token;
     }
 
-    public void sendMessage(Long id, String content, ReplyKeyboard keyboard) {
-      SendMessage sendMessage = new SendMessage();
+    public void sendMessage(Long id, String content, ReplyKeyboard keyboard) {      SendMessage sendMessage = new SendMessage();
       sendMessage.setChatId(String.valueOf(id));
       sendMessage.setText(content);
       sendMessage.setReplyMarkup(keyboard);

--- a/src/main/java/net/elytrium/limboauth/socialaddon/social/VKSocial.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/social/VKSocial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -219,6 +219,11 @@ public class VKSocial extends AbstractSocial {
   @Override
   public boolean canSend(SocialPlayer player) {
     return player.getVkID() != null;
+  }
+
+  @Override
+  public String getUserDisplayName(Long id) {
+    return String.valueOf(id);
   }
 
   public void onMessageNew(JsonObject messageNew) {

--- a/src/main/java/net/elytrium/limboauth/socialaddon/utils/GeoIp.java
+++ b/src/main/java/net/elytrium/limboauth/socialaddon/utils/GeoIp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -23,7 +23,6 @@ import com.maxmind.geoip2.exception.GeoIp2Exception;
 import com.maxmind.geoip2.model.CityResponse;
 import com.maxmind.geoip2.model.CountryResponse;
 import com.maxmind.geoip2.record.AbstractNamedRecord;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.ByteArrayInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -43,7 +42,6 @@ public class GeoIp {
   private final DatabaseReader reader;
   private final boolean cityEnabled;
 
-  @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
   public GeoIp(Path dataPath) {
     this.cityEnabled = Settings.IMP.MAIN.GEOIP.FORMAT.contains("{CITY}");
 

--- a/src/main/templates/net/elytrium/limboauth/socialaddon/BuildConstants.java
+++ b/src/main/templates/net/elytrium/limboauth/socialaddon/BuildConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Elytrium
+ * Copyright (C) 2022 - 2026 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/main/templates/net/elytrium/limboauth/socialaddon/BuildConstants.java
+++ b/src/main/templates/net/elytrium/limboauth/socialaddon/BuildConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2025 Elytrium
+ * Copyright (C) 2022 - 2023 Elytrium
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by


### PR DESCRIPTION
When multiple Minecraft accounts are linked to the same social ID, button interactions now correctly resolve to the account with an active session instead of always returning the first database entry.